### PR TITLE
fix: 422 response message

### DIFF
--- a/src/host/hooks/network/useCreateUser.ts
+++ b/src/host/hooks/network/useCreateUser.ts
@@ -48,6 +48,7 @@ export const useCreateUser = () => {
           message: `HTTP error! status: ${fetchResponse.status || fetchResponse.statusText}`,
           code: fetchResponse.status,
         });
+        setResponse(data);
       } else {
         setResponse({ ...data, authHeader });
         setStatus({ message: 'Success', code: 200 });


### PR DESCRIPTION
Response is being passed through to differentiate HTTP 422 error message more clearly, if email is already used and/or password complexity is insufficient

<img width="496" alt="image" src="https://github.com/user-attachments/assets/f9db5539-bace-43bd-ae84-73a6298fb826">
