### PR TITLE
feat: add optional `utm_data` param to createUser on useSignUpForm

### DIFF
--- a/src/host/hooks/forms/useSignUpForm.ts
+++ b/src/host/hooks/forms/useSignUpForm.ts
@@ -83,6 +83,7 @@ export const useSignUpForm = () => {
       postal_code: '',
       city: '',
       state: null,
+      utm_data: data.utmData ?? null,
     });
 
     if (success && success.authHeader) {

--- a/src/host/types/forms.ts
+++ b/src/host/types/forms.ts
@@ -39,8 +39,16 @@ export interface SignUpFormValues {
   fullName: string;
   email: string;
   password: string;
+  utmData?: UTMData;
 }
 
+interface UTMData {
+  source?: string;
+  medium?: string;
+  campaign?: string;
+  term?: string;
+  content?: string;
+}
 export interface UserCreateInput {
   email: string;
   password: string;
@@ -49,6 +57,7 @@ export interface UserCreateInput {
   postal_code: string;
   city: string;
   state: string | null;
+  utm_data: UTMData | null;
 }
 
 export interface ActiveCampaign {


### PR DESCRIPTION
I confirmed with Abhi yesterday that `utm_data` should be sent along with the signup, not as a url param on the webview.

This MR adds an optional form field that will be populated with the concatenated "clubs" value to satisfy the UTM parameter requirement on sports-connect

```bash
curl --location 'https://staging.authrewards.com/users?utm_data=%22utm_medium%3Dmobile&test=hardcoded%22' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--header 'X-REWARDS-PARTNER-ID: A2DE537C' \
--data-raw '{
    "user": {
        "email": "averma+34@flipgive.com",
        "password": "password1@P",
        "full_name": "1234 5678",
        "country": "USA",
        "postal_code": "12345",
        "city": "abcd",
        "state": "null",
        "utm_data": {
            "abcd": "en",
            "efgh": "abdceahfkjl"
        }
    }
}
'
```