### PR TITLE
fix: IOS decelerationRate='normal' for much smoother scroll experience in webview

### DIFF
--- a/src/host/screens/webStore/WebStore.tsx
+++ b/src/host/screens/webStore/WebStore.tsx
@@ -52,6 +52,7 @@ export function WebViewShop({
         onTouchEnd={onTouchEvent('end')}
         webviewDebuggingEnabled={__DEV__}
         onMessage={handleMessage}
+        decelerationRate="normal"
         {...webviewProps}
       />
     </FadeWrapper>


### PR DESCRIPTION
From Rita's research: https://github.com/react-native-webview/react-native-webview/issues/1070#issuecomment-563376514

The "deceleration" by default is really high in webview, so when you scroll in IOS it seems heavy and stops scrolling almost right away. This change makes it much smoother when scrolling


https://github.com/user-attachments/assets/d1139658-d287-446e-8bdd-76a1cb81d4c7

