### PR TITLE
Fix: offline alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@types/react": "^18.2.44"
   },
   "dependencies": {
+    "@react-native-community/netinfo": "^11.4.1",
     "react-hook-form": "^7.52.0",
     "react-native-get-random-values": "^1.11.0",
     "uuid": "^10.0.0"

--- a/src/host/components/hostCommander/index.tsx
+++ b/src/host/components/hostCommander/index.tsx
@@ -9,6 +9,7 @@ import { CreateTeamScreen } from '../../screens/teamForm';
 import { WebViewShop } from '../../screens/webStore/WebStore';
 import { UIStateType } from '../../types/context';
 import { ForgotPasswordScreen } from '../../screens/forgotPassword';
+import { NoInternetScreen } from '../../screens/nointernet';
 
 export function HostCommander() {
   const { uiState, envKeys, customComponents } = useHost();
@@ -52,6 +53,12 @@ export function HostCommander() {
         );
       case UIStateType.ShowLogout:
         return <LogoutScreen />;
+      case UIStateType.ShowNoInternet:
+        return customComponents?.CustomNoInternetScreen ? (
+          <customComponents.CustomNoInternetScreen />
+        ) : (
+          <NoInternetScreen />
+        );
       case UIStateType.ShowStore:
       default:
         const WebViewComponent =

--- a/src/host/hooks/token/useTokenInit.ts
+++ b/src/host/hooks/token/useTokenInit.ts
@@ -10,10 +10,12 @@ import { type TokenInput, UIStateType, TokenStage } from '../../types/context';
 import { getItemSecurely } from '../../utils/secureStore';
 import { useCountryField } from '../forms/useContrySelect';
 import { NetworkError } from '../../utils/networkErrors';
+import NetInfo from '@react-native-community/netinfo';
 
 export const useTokenInit = ({ automatic = true }: { automatic: boolean }) => {
   const {
     setIsLoading,
+    uiState,
     setUIState,
     saveRewardsToken,
     resetToken,
@@ -127,6 +129,24 @@ export const useTokenInit = ({ automatic = true }: { automatic: boolean }) => {
     initCall();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [envKeys]);
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
+
+    if (uiState === UIStateType.ShowNoInternet) {
+      unsubscribe = NetInfo.addEventListener((state) => {
+        if (state.isConnected) {
+          initCall();
+        }
+      });
+    }
+
+    return () => {
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
+  }, [uiState, initCall]);
 
   return { initializeRewardsToken };
 };

--- a/src/host/hooks/token/useTokenInit.ts
+++ b/src/host/hooks/token/useTokenInit.ts
@@ -9,6 +9,7 @@ import { useHost } from '../../context/HostContext';
 import { type TokenInput, UIStateType, TokenStage } from '../../types/context';
 import { getItemSecurely } from '../../utils/secureStore';
 import { useCountryField } from '../forms/useContrySelect';
+import { NetworkError } from '../../utils/networkErrors';
 
 export const useTokenInit = ({ automatic = true }: { automatic: boolean }) => {
   const {
@@ -112,6 +113,9 @@ export const useTokenInit = ({ automatic = true }: { automatic: boolean }) => {
         setUIState(UIStateType.ShowLoginForm);
       }
     } catch (error) {
+      if (error instanceof NetworkError) {
+        setUIState(UIStateType.ShowNoInternet);
+      }
     } finally {
       setIsLoading(false);
     }

--- a/src/host/screens/nointernet/index.tsx
+++ b/src/host/screens/nointernet/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ModalLoader } from '../../components/ModalLoader';
+import { View } from 'react-native';
+
+export function NoInternetScreen() {
+  return (
+    <View>
+      <ModalLoader visible={true} text="No Internet" />
+    </View>
+  );
+}

--- a/src/host/types/context.ts
+++ b/src/host/types/context.ts
@@ -7,6 +7,7 @@ export enum UIStateType {
   ShowLogout = 'showLogout',
   ShowInitialScreen = 'showInitialScreen',
   ShowForgotPassword = 'showForgotPassword',
+  ShowNoInternet = 'showNoInternet',
 }
 
 export enum TokenStage {

--- a/src/host/types/modules.ts
+++ b/src/host/types/modules.ts
@@ -25,6 +25,7 @@ export interface RewardsTypes {
     CustomModalLoader?: ComponentType;
     CustomInitialScreen?: ComponentType;
     CustomForgotPasswordScreen?: ComponentType;
+    CustomNoInternetScreen?: ComponentType;
   };
   children?: React.ReactNode;
   options?: {

--- a/src/host/utils/networkErrors.ts
+++ b/src/host/utils/networkErrors.ts
@@ -1,0 +1,6 @@
+export class NetworkError extends Error {
+  constructor(message?: string) {
+    super(message || 'Network request failed');
+    this.name = 'NetworkError';
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2476,6 +2476,7 @@ __metadata:
   dependencies:
     "@commitlint/config-conventional": ^17.0.2
     "@evilmartians/lefthook": ^1.5.0
+    "@react-native-community/netinfo": ^11.4.1
     "@react-native/eslint-config": ^0.73.1
     "@release-it/conventional-changelog": ^5.0.0
     "@types/jest": ^29.5.5
@@ -3366,6 +3367,15 @@ __metadata:
   bin:
     rnc-cli: build/bin.js
   checksum: 2a36e7d1ec650a0ce5c478572b698416fa5ca23a96f18f1556f9ac5c973bd94409952741d118dae9b5f9e9d5edd582d79e815a8601c50afb81b85f2433ddcdfa
+  languageName: node
+  linkType: hard
+
+"@react-native-community/netinfo@npm:^11.4.1":
+  version: 11.4.1
+  resolution: "@react-native-community/netinfo@npm:11.4.1"
+  peerDependencies:
+    react-native: ">=0.59"
+  checksum: d347ae522da6b8c045d6378754d4928bdf23cc85b74571b91fa8a03fa168bdac5e3c65eb97eac0dd0c7cbd20e782f99d41b090fb79ce7d815cbaf6fb5d1abe37
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Proposed fix for [[No Internet Experience]](https://app.clickup.com/t/86dupth9b)

Currently if you are logged in and restart the app with no internet, it will take you to the sign in page, which is undesirable.

This fix adds a new custom screen if the network connection fails and with the help of the `@react-native-community/netinfo` package it retries until the connection is restored.

![Screenshot_1729624545](https://github.com/user-attachments/assets/9a9acf00-c3da-456c-9b2a-8157b9a8cb9e)

## Testing notes: 
[(From Stackoverflow)](https://stackoverflow.com/questions/4808433/is-it-possible-to-disable-the-network-in-ios-simulator)
In Xcode, you can go to menu Open Developer Tools → More Developer Tools and download "[Additional Tools for Xcode](https://developer.apple.com/download/more/?name=Additional%20Tools%20for%20Xcode)", which will have the Network Link Conditioner.

Using this tool, you can simulate different network scenarios (such as 100% loss, 3G, high-latency DNS, and more) and you can create your own custom ones as well.

I put the terminal window right beside the Network Link Conditioner tool and simulate a 100% signal loss right after restarting the app